### PR TITLE
Removed use of client-cfg-parms in ietf-bfd-mpls.yang 

### DIFF
--- a/src/yang/ietf-bfd-mpls.yang
+++ b/src/yang/ietf-bfd-mpls.yang
@@ -6,13 +6,13 @@ module ietf-bfd-mpls {
   import ietf-bfd-types {
     prefix bfd-types;
     reference
-      "RFC 9127: YANG Data Model for Bidirectional Forwarding
+      "RFC XXXX: YANG Data Model for Bidirectional Forwarding
        Detection (BFD)";
   }
   import ietf-bfd {
     prefix bfd;
     reference
-      "RFC 9127: YANG Data Model for Bidirectional Forwarding
+      "RFC XXXX: YANG Data Model for Bidirectional Forwarding
        Detection (BFD)";
   }
   import ietf-inet-types {
@@ -60,9 +60,16 @@ module ietf-bfd-mpls {
   reference
     "RFC 5884: Bidirectional Forwarding Detection (BFD)
      for MPLS Label Switched Paths (LSPs)
-     RFC 9127: YANG Data Model for Bidirectional Forwarding
+     RFC XXXX: YANG Data Model for Bidirectional Forwarding
      Detection (BFD)";
 
+  revision YYYY-MM-DD {
+    description
+      "RFC XXXX.";
+    reference
+      "RFC XXXX: YANG Data Model for Bidirectional Forwarding
+       Detection (BFD).";
+  }
   revision 2021-10-21 {
     description
       "Initial revision.";
@@ -136,7 +143,13 @@ module ietf-bfd-mpls {
       container egress {
         description
           "Egress configuration.";
-        uses bfd-types:client-cfg-parms;
+        leaf enabled {
+          type boolean;
+          default "false";
+          description
+            "Indicates whether BFD over MPLS is enabled.";
+        }
+        uses bfd-types:base-cfg-parms;
         uses bfd-types:auth-parms;
       }
       container session-groups {


### PR DESCRIPTION
So that we don't depend on the new client feature.

Instead we use base-cfg-parms and add an "enabled" leaf.

https://github.com/mjethanandani/rfc9127-bis/issues/11

```
$ diff /home/vagrant/YANG/rfc9127-bis/src/yang/ietf-bfd-mpls.txt /home/vagrant/YANG/rfc9127-bis/src/yang/ietf-bfd-mpls-new.txt 
12,13c12,13
<        |  +--rw local-multiplier?                 multiplier {client-cfg-parameters}?
<        |  +--rw (interval-config-type)? {client-cfg-parameters}?
---
>        |  +--rw local-multiplier?                 multiplier
>        |  +--rw (interval-config-type)?
```
