### PR TITLE
Add comment on IANA BFD types module

### DIFF
--- a/draft/draft-ietf-bfd-rfc9127-bis.xml
+++ b/draft/draft-ietf-bfd-rfc9127-bis.xml
@@ -2297,7 +2297,9 @@ module example-bfd-echo {
       over a given interface, as well as when they need to be
       defined per session. As a result, the BFD MPLS module has to
       use the base-cfg-parms instead of client-cfg-parms to be able
-      to include all the parameters unconditionally. The
+      to include all the parameters unconditionally.
+      </t>
+      <t>The
       iana-bfd-types module, created in RFC 9127, was delegated to
       IANA for maintenance. No changes are requested from IANA as
       part of this update.

--- a/draft/draft-ietf-bfd-rfc9127-bis.xml
+++ b/draft/draft-ietf-bfd-rfc9127-bis.xml
@@ -2297,7 +2297,10 @@ module example-bfd-echo {
       over a given interface, as well as when they need to be
       defined per session. As a result, the BFD MPLS module has to
       use the base-cfg-parms instead of client-cfg-parms to be able
-      to include all the parameters unconditionally.
+      to include all the parameters unconditionally. The
+      iana-bfd-types module, created in RFC 9127, was delegated to
+      IANA for maintenance. No changes are requested from IANA as
+      part of this update.
       </t>
     </section>
   </back>


### PR DESCRIPTION
The iana-bfd-types module was removed in this draft. Adding a comment about it.